### PR TITLE
Add workflow to update changelog on release

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v6
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that updates CHANGELOG.md when a release is published

## Testing
- composer test
- vendor/bin/phpstan analyse --memory-limit=1G
- vendor/bin/php-cs-fixer fix --config=.php_cs.dist.php --dry-run --diff

------
https://chatgpt.com/codex/tasks/task_b_68cf4577c448833387d6852a987a8371