### PR TITLE
Add Packagist and CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Laravel Sharding
 
+[![Packagist Version](https://img.shields.io/packagist/v/allnetru/laravel-sharding.svg)](https://packagist.org/packages/allnetru/laravel-sharding)
+[![Tests](https://github.com/allnetru/laravel-sharding/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/allnetru/laravel-sharding/actions/workflows/run-tests.yml)
+
 Laravel Sharding is a toolkit for distributing data across multiple databases while keeping a familiar Eloquent workflow. The package powers production applications and provides pluggable strategies so each table can select the most appropriate sharding approach.
 
 ## Requirements


### PR DESCRIPTION
## Summary
- add a Packagist version badge to the README
- add a GitHub Actions test status badge that points to the run-tests workflow

## Testing
- composer test
- vendor/bin/phpstan analyse --memory-limit=1G
- vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php_cs.dist.php

------
https://chatgpt.com/codex/tasks/task_b_68cf5419bcc48333b5eaa452b0df9808