### PR TITLE
Configure phpunit to use in-memory SQLite

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,4 +9,9 @@
             <directory suffix="Test.php">tests/Feature</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
## Summary
- configure PHPUnit to inject sqlite connection defaults for package tests
- omit unrelated environment overrides after confirming the package does not rely on them

## Testing
- composer test
- vendor/bin/phpstan analyse --memory-limit=1G
- vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php_cs.dist.php

------
https://chatgpt.com/codex/tasks/task_b_68cf56b4f1488333a05b5302620d8177