### PR TITLE
docs: update README strategy configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,19 @@ DB_SHARD_MIGRATIONS="shard-legacy;shard-archive"
 return [
     'default' => 'hash',
 
+    'strategies' => [
+        'hash' => Allnetru\Sharding\Strategies\HashStrategy::class,
+        'redis' => Allnetru\Sharding\Strategies\RedisStrategy::class,
+        'range' => Allnetru\Sharding\Strategies\RangeStrategy::class,
+        'db_range' => Allnetru\Sharding\Strategies\DbRangeStrategy::class,
+        'db_hash_range' => Allnetru\Sharding\Strategies\DbHashRangeStrategy::class,
+    ],
+
     'id_generator' => [
         'default' => 'snowflake',
         'strategies' => [
-            'snowflake' => Allnetru\\Sharding\\IdGenerators\\SnowflakeStrategy::class,
-            'sequence' => Allnetru\\Sharding\\IdGenerators\\TableSequenceStrategy::class,
+            'snowflake' => Allnetru\Sharding\IdGenerators\SnowflakeStrategy::class,
+            'sequence' => Allnetru\Sharding\IdGenerators\TableSequenceStrategy::class,
         ],
         'sequence_table' => 'shard_sequences',
         // 'meta_connection' => 'mysql',


### PR DESCRIPTION
## Summary
- add the strategy registry example to the README configuration snippet
- fix the namespace escaping for the snowflake and sequence ID generator examples

## Testing
- composer test
- vendor/bin/phpstan analyse --memory-limit=1G
- vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php_cs.dist.php

------
https://chatgpt.com/codex/tasks/task_b_68cf5fe249a8833388ff17efa05ac05f