### PR TITLE
Update PHPUnit configuration and composer scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ Run the local quality checks before submitting changes:
 
 ```bash
 composer test
-vendor/bin/phpstan analyse
-vendor/bin/php-cs-fixer fix --dry-run --diff
+composer analyse
+composer lint
 ```
 
 ## QA and Release

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "analyse": "vendor/bin/phpstan analyse",
-        "test-coverage": "vendor/bin/phpunit --coverage-text",
+        "lint": "vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php_cs.dist.php",
+        "test-coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text",
         "baseline": "vendor/bin/phpstan --generate-baseline"
     },
     "config": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,11 @@
             <directory suffix="Test.php">tests/Feature</directory>
         </testsuite>
     </testsuites>
-
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
     <php>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>


### PR DESCRIPTION
## Summary
- include the `src` directory in the PHPUnit configuration so code coverage targets package classes
- update Composer scripts to expose php-cs-fixer via `composer lint` and ensure coverage runs with `XDEBUG_MODE=coverage`
- align contributor instructions to use the Composer wrappers for analysis and linting

## Testing
- composer test
- composer analyse -- --memory-limit=1G
- composer lint

------
https://chatgpt.com/codex/tasks/task_b_68cf67dd2d4483339a3888945a69ddb6