### PR TITLE
Simplify shard env usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,17 @@ return [
         ],
 
         // other non-sharded connections...
-    ], Shards::databaseConnections()),
+    ], Shards::databaseConnections(env('DB_SHARDS', ''))),
 
     // ...
 ];
 ```
+
+> **Note**
+> Passing the `DB_SHARDS` string ensures shard definitions are available while
+> configuration files are still being evaluated. In other contexts you may call
+> `Shards::databaseConnections()` without arguments and it will read the
+> `DB_SHARDS` environment variable directly.
 
 A full walkthrough is available in [docs/en/sharding.md](docs/en/sharding.md).
 

--- a/config/sharding.php
+++ b/config/sharding.php
@@ -1,5 +1,7 @@
 <?php
 
+use Allnetru\Sharding\Support\Config\Shards;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -10,27 +12,6 @@ return [
     | Supported strategies are registered in the `strategies` array below.
     */
     'default' => 'hash',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Environment configuration
-    |--------------------------------------------------------------------------
-    |
-    | Capture environment-driven values so they remain accessible after the
-    | config cache is generated. Runtime helpers pull values from this array
-    | instead of calling env() outside of this file.
-    */
-    'env' => [
-        'driver' => env('DB_SHARD_DRIVER', 'mysql'),
-        'username' => env('DB_USERNAME', 'forge'),
-        'password' => env('DB_PASSWORD', ''),
-        'charset' => env('DB_CHARSET', 'utf8mb4'),
-        'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
-        'port' => env('DB_PORT', '3306'),
-        'mysql_attr_ssl_ca' => env('MYSQL_ATTR_SSL_CA'),
-        'db_shards' => env('DB_SHARDS', ''),
-        'db_shard_migrations' => env('DB_SHARD_MIGRATIONS', ''),
-    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -78,8 +59,8 @@ return [
     | shard names via the DB_SHARDS variable. You may also temporarily exclude
     | shards from selection by listing them in DB_SHARD_MIGRATIONS.
     */
-    'connections' => Allnetru\Sharding\Support\Config\Shards::weights(),
-    'migrations' => Allnetru\Sharding\Support\Config\Shards::migrations(),
+    'connections' => Shards::weights(env('DB_SHARDS')),
+    'migrations' => Shards::migrations(env('DB_SHARD_MIGRATIONS')),
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/en/sharding.md
+++ b/docs/en/sharding.md
@@ -38,11 +38,16 @@ return [
             // ... keep your existing base connections here
         ],
         // other non-sharded connections...
-    ], Shards::databaseConnections()),
+    ], Shards::databaseConnections(env('DB_SHARDS', ''))),
 
     // ...
 ];
 ```
+
+> **Tip**
+> Passing the `DB_SHARDS` string makes the helper work during the configuration
+> bootstrap phase. In other contexts you can call the helper without arguments
+> and it will read the `DB_SHARDS` environment variable directly.
 
 ### Creating a sharded table
 

--- a/tests/Unit/ShardsConfigTest.php
+++ b/tests/Unit/ShardsConfigTest.php
@@ -12,13 +12,66 @@ class ShardsConfigTest extends TestCase
     #[DataProvider('invalidDsnProvider')]
     public function test_invalid_dsn_is_excluded(string $dsn): void
     {
-        config(['sharding.env.db_shards' => $dsn]);
         Log::shouldReceive('warning')->twice()->with(sprintf('Invalid shard DSN: %s', $dsn));
 
-        $this->assertSame([], Shards::databaseConnections());
-        $this->assertSame([], Shards::weights());
+        $this->assertSame([], Shards::databaseConnections($dsn));
+        $this->assertSame([], Shards::weights($dsn));
+    }
 
-        config(['sharding.env.db_shards' => '']);
+    public function test_helpers_fall_back_to_env_when_config_not_loaded(): void
+    {
+        $originalConfig = config('sharding');
+
+        config(['sharding' => null]);
+
+        $previousShards = getenv('DB_SHARDS');
+        $previousPort = getenv('DB_PORT');
+
+        $dsn = 'fallback-shard:db-fallback::sharded_db';
+
+        putenv("DB_SHARDS={$dsn}");
+        $_ENV['DB_SHARDS'] = $dsn;
+        $_SERVER['DB_SHARDS'] = $dsn;
+
+        putenv('DB_PORT=3310');
+        $_ENV['DB_PORT'] = '3310';
+        $_SERVER['DB_PORT'] = '3310';
+
+        try {
+            $connections = Shards::databaseConnections();
+
+            $this->assertArrayHasKey('fallback-shard', $connections);
+
+            $this->assertSame('db-fallback', $connections['fallback-shard']['host']);
+            $this->assertSame('3310', $connections['fallback-shard']['port']);
+            $this->assertSame('sharded_db', $connections['fallback-shard']['database']);
+
+            $this->assertSame([
+                'fallback-shard' => ['weight' => 1],
+            ], Shards::weights());
+
+            $this->assertSame([], Shards::migrations());
+        } finally {
+            if ($previousShards === false) {
+                putenv('DB_SHARDS');
+                unset($_ENV['DB_SHARDS'], $_SERVER['DB_SHARDS']);
+            } else {
+                putenv("DB_SHARDS={$previousShards}");
+                $_ENV['DB_SHARDS'] = $previousShards;
+                $_SERVER['DB_SHARDS'] = $previousShards;
+            }
+
+            if ($previousPort === false) {
+                putenv('DB_PORT');
+                unset($_ENV['DB_PORT'], $_SERVER['DB_PORT']);
+            } else {
+                putenv("DB_PORT={$previousPort}");
+                $_ENV['DB_PORT'] = $previousPort;
+                $_SERVER['DB_PORT'] = $previousPort;
+            }
+
+            config(['sharding' => $originalConfig]);
+        }
     }
 
     public static function invalidDsnProvider(): array


### PR DESCRIPTION
## Summary
- drop the cached environment array from the sharding config and resolve shard credentials with direct env lookups guarded by a helper
- update the sharding helpers, configuration, and docs to expect `DB_SHARDS` / `DB_SHARD_MIGRATIONS` strings to be passed explicitly during bootstrap
- refresh the shard config tests to avoid relying on `config('sharding.env')`

## Testing
- composer test
- composer analyse -- --memory-limit=512M
- composer lint

------
https://chatgpt.com/codex/tasks/task_b_68cfd800677c8333b2b1d30667b656fa