### PR TITLE
chore: update CHANGELOG for v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.1.4 - 2025-09-22
+
+### What's Changed
+
+* Gitflow changelog pr by PAT secret by @allnetru in https://github.com/allnetru/laravel-sharding/pull/20
+
+**Full Changelog**: https://github.com/allnetru/laravel-sharding/compare/v0.1.3...v0.1.4
+
 ## v0.1.1 - 2025-09-21
 
 ### What's Changed


### PR DESCRIPTION
This PR updates **CHANGELOG.md** from the released notes.
- Release: `v0.1.4`
- Triggered by `release: released`