### PR TITLE
Handle unique constraint violations across drivers

### DIFF
--- a/src/IdGenerators/TableSequenceStrategy.php
+++ b/src/IdGenerators/TableSequenceStrategy.php
@@ -3,6 +3,7 @@
 namespace Allnetru\Sharding\IdGenerators;
 
 use Allnetru\Sharding\Models\ShardSequence;
+use Allnetru\Sharding\Support\Database\UniqueConstraintViolationDetector;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
@@ -46,7 +47,7 @@ class TableSequenceStrategy implements Strategy
 
                 return 1;
             } catch (QueryException $e) {
-                if ($e->getCode() !== '23000') {
+                if (!UniqueConstraintViolationDetector::causedBy($e)) {
                     throw $e;
                 }
 

--- a/src/Strategies/DbHashRangeStrategy.php
+++ b/src/Strategies/DbHashRangeStrategy.php
@@ -3,6 +3,7 @@
 namespace Allnetru\Sharding\Strategies;
 
 use Allnetru\Sharding\Models\ShardSlot;
+use Allnetru\Sharding\Support\Database\UniqueConstraintViolationDetector;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
@@ -222,7 +223,7 @@ class DbHashRangeStrategy implements RowMoveAware, Strategy
 
                     return;
                 } catch (QueryException $e) {
-                    if ($e->getCode() !== '23000') {
+                    if (!UniqueConstraintViolationDetector::causedBy($e)) {
                         throw $e;
                     }
 

--- a/src/Support/Database/UniqueConstraintViolationDetector.php
+++ b/src/Support/Database/UniqueConstraintViolationDetector.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Allnetru\Sharding\Support\Database;
+
+use Illuminate\Database\QueryException;
+use PDOException;
+
+/**
+ * Determines whether a query failure was caused by a duplicate key constraint.
+ */
+final class UniqueConstraintViolationDetector
+{
+    /**
+     * SQLSTATE codes that indicate a unique constraint violation.
+     *
+     * @var array<int, string>
+     */
+    private const SQLSTATE_CODES = [
+        '23000', // MySQL, SQLite, SQL Server
+        '23505', // PostgreSQL
+    ];
+
+    /**
+     * Driver specific error codes for unique constraint violations.
+     *
+     * @var array<int, int>
+     */
+    private const DRIVER_ERROR_CODES = [
+        1062, // MySQL duplicate entry
+        2601, // SQL Server duplicate key
+        2627, // SQL Server unique constraint violation
+    ];
+
+    /**
+     * Check if the given query exception resulted from a unique constraint violation.
+     *
+     * @param QueryException $exception
+     *
+     * @return bool
+     */
+    public static function causedBy(QueryException $exception): bool
+    {
+        if (self::matchesQueryException($exception)) {
+            return true;
+        }
+
+        $previous = $exception->getPrevious();
+        if ($previous instanceof PDOException) {
+            return self::matchesErrorSignature($previous->errorInfo ?? null, $previous->getCode());
+        }
+
+        return false;
+    }
+
+    /**
+     * Inspect the QueryException payload for markers of a duplicate key violation.
+     *
+     * @param QueryException $exception
+     *
+     * @return bool
+     */
+    private static function matchesQueryException(QueryException $exception): bool
+    {
+        $errorInfo = $exception->errorInfo ?? null;
+
+        if (self::matchesErrorSignature($errorInfo, $exception->getCode())) {
+            return true;
+        }
+
+        if ($errorInfo !== null && isset($errorInfo[2]) && is_string($errorInfo[2])) {
+            $message = strtolower($errorInfo[2]);
+            if (str_contains($message, 'duplicate') || str_contains($message, 'unique constraint')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Compare SQLSTATE and driver-specific codes to a known duplicate key signature.
+     *
+     * @param array<int, mixed>|null $errorInfo
+     * @param string|int|null $code
+     *
+     * @return bool
+     */
+    private static function matchesErrorSignature(?array $errorInfo, string|int|null $code): bool
+    {
+        if ($code !== null && self::matchesCode($code)) {
+            return true;
+        }
+
+        if (!$errorInfo) {
+            return false;
+        }
+
+        $sqlState = $errorInfo[0] ?? null;
+        if (is_string($sqlState) && self::matchesSqlState($sqlState)) {
+            return true;
+        }
+
+        $driverCode = $errorInfo[1] ?? null;
+        if (is_int($driverCode) && self::matchesDriverCode($driverCode)) {
+            return true;
+        }
+        if (is_string($driverCode) && self::matchesCode($driverCode)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Normalise an SQLSTATE or driver error code for comparison.
+     *
+     * @param string|int $code
+     *
+     * @return bool
+     */
+    private static function matchesCode(string|int $code): bool
+    {
+        if (is_int($code)) {
+            return self::matchesDriverCode($code) || self::matchesSqlState((string) $code);
+        }
+
+        $normalized = trim($code);
+
+        if (self::matchesSqlState($normalized)) {
+            return true;
+        }
+
+        if (ctype_digit($normalized) && self::matchesDriverCode((int) $normalized)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the provided code belongs to the SQLSTATE class of unique violations.
+     *
+     * @param string $code
+     *
+     * @return bool
+     */
+    private static function matchesSqlState(string $code): bool
+    {
+        return in_array(strtoupper($code), self::SQLSTATE_CODES, true);
+    }
+
+    /**
+     * Determine whether the provided driver error code represents a duplicate entry violation.
+     *
+     * @param int $code
+     *
+     * @return bool
+     */
+    private static function matchesDriverCode(int $code): bool
+    {
+        return in_array($code, self::DRIVER_ERROR_CODES, true);
+    }
+}

--- a/tests/Unit/Support/Database/UniqueConstraintViolationDetectorTest.php
+++ b/tests/Unit/Support/Database/UniqueConstraintViolationDetectorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Allnetru\Sharding\Tests\Unit\Support\Database;
+
+use Allnetru\Sharding\Support\Database\UniqueConstraintViolationDetector;
+use Illuminate\Database\QueryException;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Allnetru\Sharding\Support\Database\UniqueConstraintViolationDetector
+ */
+class UniqueConstraintViolationDetectorTest extends TestCase
+{
+    /**
+     * @param array<int, mixed>|null $errorInfo
+     * @param string|int|null $code
+     * @param bool $expected
+     *
+     * @dataProvider detectionDataProvider
+     */
+    public function testDetectorRecognisesUniqueConstraintViolations(?array $errorInfo, string|int|null $code, bool $expected): void
+    {
+        $exception = $this->makeException($errorInfo, $code);
+
+        $this->assertSame($expected, UniqueConstraintViolationDetector::causedBy($exception));
+    }
+
+    /**
+     * @return array<string, array{array<int, mixed>|null, string|int|null, bool}>
+     */
+    public static function detectionDataProvider(): array
+    {
+        return [
+            'mysql-sqlstate' => [
+                ['23000', 1062, 'Duplicate entry'],
+                23000,
+                true,
+            ],
+            'postgres-sqlstate' => [
+                ['23505', '23505', 'duplicate key value violates unique constraint'],
+                0,
+                true,
+            ],
+            'sqlsrv-driver-code' => [
+                ['23000', 2627, 'Violation of UNIQUE KEY constraint'],
+                'HY000',
+                true,
+            ],
+            'message-fallback' => [
+                ['HY000', 500, 'UNIQUE constraint failed: main.users_email_unique'],
+                'HY000',
+                true,
+            ],
+            'postgres-foreign-key' => [
+                ['23503', '23503', 'insert or update on table violates foreign key constraint'],
+                0,
+                false,
+            ],
+            'missing-error-info' => [
+                null,
+                0,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, mixed>|null $errorInfo
+     * @param string|int|null $code
+     */
+    private function makeException(?array $errorInfo, string|int|null $code): QueryException
+    {
+        $pdoCode = 0;
+        if (is_int($code)) {
+            $pdoCode = $code;
+        } elseif (is_string($code) && ctype_digit($code)) {
+            $pdoCode = (int) $code;
+        }
+
+        $previous = new PDOException('error', $pdoCode);
+        if ($errorInfo !== null) {
+            $previous->errorInfo = $errorInfo;
+        }
+
+        $exception = new QueryException('sqlite', 'insert', [], $previous);
+
+        if (is_string($code) && !ctype_digit($code)) {
+            $this->setQueryExceptionCode($exception, $code);
+        }
+
+        return $exception;
+    }
+
+    private function setQueryExceptionCode(QueryException $exception, string $code): void
+    {
+        $reflection = new \ReflectionProperty(QueryException::class, 'code');
+        $reflection->setAccessible(true);
+        $reflection->setValue($exception, $code);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable detector for unique constraint violations that recognises SQLSTATEs from MySQL, PostgreSQL and SQL Server
- use the detector inside the table sequence generator and DB hash range strategy to retry safely across drivers
- cover the detector with unit tests that simulate driver-specific SQLSTATE and error info combinations
- standardise the detector PHPDoc annotations to list only parameter and return types

## Testing
- composer test
- PHP_MEMORY_LIMIT=512M composer analyse -- --memory-limit=512M
- composer lint

------
https://chatgpt.com/codex/tasks/task_b_68d14063bd908333baf4b008e8269941