### PR TITLE
chore: update CHANGELOG for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.2.0 - 2026-03-18
+
+### What's Changed
+
+* chore: update CHANGELOG for v0.1.6 by @allnetru in https://github.com/allnetru/laravel-sharding/pull/33
+* Laravel 13 by @allnetru in https://github.com/allnetru/laravel-sharding/pull/34
+
+**Full Changelog**: https://github.com/allnetru/laravel-sharding/compare/v0.1.6...v0.2.0
+
 ## v0.1.6 - 2026-03-18
 
 ### What's Changed


### PR DESCRIPTION
This PR updates **CHANGELOG.md** from the released notes.
- Release: `v0.2.0`
- Triggered by `release: released`