### PR TITLE
fix: Laravel 13 compatibility for ShardBuilder::updateOrCreate

### DIFF
--- a/src/ShardBuilder.php
+++ b/src/ShardBuilder.php
@@ -316,8 +316,12 @@ class ShardBuilder extends EloquentBuilder
     /**
      * @inheritdoc
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes, Closure|array $values = [])
     {
+        if ($values instanceof Closure) {
+            $values = $values();
+        }
+
         if ($instance = $this->firstAcrossConnections($attributes)) {
             $instance->fill($values);
             $instance->save();


### PR DESCRIPTION
## Problem

Every `L^13.0` job in the `run-tests` matrix has been failing on `main` (and therefore on every open PR) with:

```
Fatal error: Premature end of PHP process when running
Allnetru\Sharding\Tests\Unit\ShardBelongsToRelationTest::testBelongsToLoadsAcrossShards.
```

The message hides the real error. Running the same job with `display_errors=1` shows it:

```
Fatal error: Declaration of Allnetru\Sharding\ShardBuilder::updateOrCreate(array $attributes, array $values = [])
must be compatible with Illuminate\Database\Eloquent\Builder::updateOrCreate(array $attributes, Closure|array $values = [])
in src/ShardBuilder.php on line 319
```

Laravel 13 widened `Builder::updateOrCreate()` to accept `Closure|array $values`. Our override still declared `array $values`, so PHP fatals the moment `ShardBuilder` is autoloaded — which happens in `Shardable::newEloquentBuilder()` on the first `save()`. The crash is unrelated to whichever test happens to load the class first.

`firstOrCreate()` was already widened when Laravel 13 support was added in #34; `updateOrCreate()` was missed.

## Fix

Widen the `$values` parameter to `Closure|array` and resolve the closure before use, mirroring `firstOrCreate()`. Parameter contravariance keeps the signature valid against Laravel 12's narrower `array $values` too, so the `^12.0` legs are unaffected.

## Verification

Ran the full suite locally against each matrix leg (PHP 8.3):

| Leg | Result |
| --- | --- |
| `L^13.0` prefer-stable | OK (85 tests, 232 assertions) |
| `L^13.0` prefer-lowest | OK (85 tests, 232 assertions) |
| `L^12.0` (current lock) | OK (85 tests, 232 assertions) |

`composer lint` and `composer analyse` (PHPStan level 5) are both clean.

Unblocks #37 and #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)